### PR TITLE
support i18n error messages

### DIFF
--- a/lib/username_not_reserved_validator.rb
+++ b/lib/username_not_reserved_validator.rb
@@ -27,7 +27,7 @@ class UsernameNotReservedValidator < ActiveModel::EachValidator
     end
 
     if words.include?(username)
-      record.errors[attribute] << (options[:message] || :invalid)
+      record.errors.add(attribute, (options[:message] || :invalid))
     end
   end
 end


### PR DESCRIPTION
use `errors.add`

```ruby
user = User.new

# before
user.errors[:name] << :invalid
user.errors[:name]
# => [:invalid]

# after
user.errors.add(:name, :invalid)
user.errors[:name]
# => ["is invalid"]

# after still support custom error message
user.errors.add(:name, "Some message")
user.errors[:name]
# => ["Some message"]
```
